### PR TITLE
Add MCP hello-world prototype under python/mcp-hello

### DIFF
--- a/python/mcp-hello/.env.example
+++ b/python/mcp-hello/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in your values.
+# The .env file is read automatically by python-dotenv.
+
+# Required — get yours at https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional overrides (defaults shown)
+# MCP_SERVER_URL=http://localhost:8000/mcp
+# MCP_HOST=0.0.0.0
+# MCP_PORT=8000
+# WEBAPP_PORT=5000

--- a/python/mcp-hello/Dockerfile
+++ b/python/mcp-hello/Dockerfile
@@ -1,0 +1,27 @@
+# Single image used for both the MCP server and the web chatbot.
+# docker-compose overrides CMD per service.
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies first (layer-cache friendly)
+COPY pyproject.toml .
+RUN pip install --no-cache-dir \
+    "mcp[cli]>=1.6.0" \
+    "anthropic>=0.45.0" \
+    "flask>=3.1.0" \
+    "pytz>=2024.1" \
+    "python-dotenv>=1.0.0"
+
+# Copy source
+COPY server.py webapp.py ./
+COPY templates/ templates/
+
+# Default: run the MCP server in HTTP mode
+# (docker-compose overrides this for the chatbot service)
+EXPOSE 8000
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=8000
+
+CMD ["python", "server.py", "--transport", "http"]

--- a/python/mcp-hello/README.md
+++ b/python/mcp-hello/README.md
@@ -1,0 +1,229 @@
+# MCP Hello World — prototype
+
+A minimal **Model Context Protocol (MCP)** server demo with three run modes,
+all working locally on macOS.
+
+```
+python/mcp-hello/
+├── server.py                  # FastMCP server — tools + resource
+├── client.py                  # CLI chatbot (stdio transport)
+├── webapp.py                  # Web chatbot (HTTP transport)
+├── templates/index.html       # Vanilla HTML/JS chat UI
+├── Dockerfile                 # Single image for server + webapp
+├── docker-compose.yml         # Full stack: mcp-server + chatbot
+├── pyproject.toml
+├── .env.example
+└── claude_desktop_config.json # Snippet for Claude Desktop
+```
+
+---
+
+## How MCP works
+
+```
+ MCP Client (Claude Desktop / CLI bot / web chatbot)
+ ────────────────────────────────────────────────────
+ 1. list_tools()         discovers what the server can do
+ 2. Claude API call      Claude sees the tool schemas + user message
+ 3. tool_use response    Claude asks to call a specific tool
+ 4. call_tool()          client executes it on the MCP server
+ 5. tool_result          Claude gets the data, writes final answer
+        │
+        │  stdio  OR  streamable-http
+        ▼
+ MCP Server  (server.py — FastMCP)
+ ────────────────────────────────────────────────────
+ Tools:    greet · get_time · add · reverse · word_stats
+ Resource: mcp://hello/welcome
+```
+
+Two transports are supported:
+
+| Transport | How the server runs | Used by |
+|---|---|---|
+| **stdio** | Client spawns server as subprocess; JSON-RPC over stdin/stdout | CLI chatbot, Claude Desktop, MCP Inspector |
+| **streamable-http** | Server runs as a standalone process on port 8000 | Web chatbot, Docker Compose |
+
+---
+
+## Prerequisites
+
+```bash
+cd python/mcp-hello
+
+# Create a virtual environment
+python -m venv .venv && source .venv/bin/activate
+
+# Install all dependencies
+pip install -e .
+# or with uv:  uv sync
+
+# Set your Anthropic API key
+cp .env.example .env
+# then edit .env and set ANTHROPIC_API_KEY=sk-ant-...
+```
+
+---
+
+## Option 1 — CLI chatbot (simplest, no Docker)
+
+`client.py` spawns `server.py` as a subprocess automatically — no server setup needed.
+
+```bash
+python client.py                          # interactive loop
+python client.py "Greet me as a pirate"   # single query
+```
+
+Sample output:
+
+```
+[MCP] Connected. Tools: ['greet', 'get_time', 'add', 'reverse', 'word_stats']
+
+MCP Chatbot — type 'quit' or Ctrl-C to exit.
+
+You: Greet me as a pirate and tell me the time in Tokyo
+  [tool] greet({'name': 'you', 'style': 'pirate'})    → Ahoy, you! Welcome aboard...
+  [tool] get_time({'timezone': 'Asia/Tokyo'})           → Current time in Asia/Tokyo: 2026-03-29 14:32 JST
+Assistant: Ahoy, you! Welcome aboard, ye landlubber! Here is the time in Tokyo: 2026-03-29 14:32 JST
+```
+
+---
+
+## Option 2 — Web chatbot with HTML UI (Docker Compose)
+
+This option runs the MCP server as a separate HTTP service and the chatbot
+as a Flask web app. Both run in Docker.
+
+### 2a. Docker Compose (recommended for Docker Desktop demo)
+
+```bash
+# Build and start both services
+ANTHROPIC_API_KEY=sk-ant-... docker compose up --build
+
+# Open the chatbot in your browser
+open http://localhost:5000
+```
+
+The compose file starts:
+- **mcp-server** on port 8000 — the FastMCP server in HTTP mode
+- **chatbot** on port 5000 — the Flask web app that connects to it
+
+### 2b. Run locally without Docker
+
+```bash
+# Terminal 1 — start the MCP server in HTTP mode
+python server.py --transport http
+# Listening at http://0.0.0.0:8000/mcp
+
+# Terminal 2 — start the web chatbot
+python webapp.py
+# open http://localhost:5000
+```
+
+---
+
+## Option 3 — Claude Desktop (GUI, no code needed)
+
+Claude Desktop natively supports MCP servers. Once configured, every conversation
+in Claude Desktop can call your tools transparently.
+
+1. Copy the snippet from `claude_desktop_config.json` into Claude's config:
+
+```bash
+open "~/Library/Application Support/Claude/claude_desktop_config.json"
+```
+
+Add (or merge) the `mcpServers` block, replacing the path:
+
+```json
+{
+  "mcpServers": {
+    "hello-world": {
+      "command": "python",
+      "args": ["/absolute/path/to/python/mcp-hello/server.py"]
+    }
+  }
+}
+```
+
+2. Quit and reopen Claude Desktop.
+3. A hammer icon appears in the chat input — click it to see your tools.
+4. Chat naturally: *"What time is it in Paris?"* — Claude calls `get_time` automatically.
+
+---
+
+## Option 4 — MCP Inspector (interactive debugging)
+
+The Inspector gives you a browser UI to explore and manually test the server
+without writing any client code. No installation required.
+
+```bash
+# Inspect the server via stdio (same as CLI client)
+npx @modelcontextprotocol/inspector python server.py
+
+# Then open http://localhost:6274 in your browser
+```
+
+The Inspector lets you:
+- Browse all tools and their JSON schemas
+- Call any tool with custom inputs and see raw responses
+- Read resources
+- Watch server logs in real time
+
+This is the best way to understand exactly what the MCP server exposes.
+
+---
+
+## Tools reference
+
+| Tool | Arguments | Example |
+|---|---|---|
+| `greet` | `name`, `style` (`friendly`/`formal`/`pirate`) | "Greet Alice as a pirate" |
+| `get_time` | `timezone` (IANA, default `UTC`) | "Time in US/Pacific" |
+| `add` | `a`, `b` (floats) | "Add 42 and 3.14" |
+| `reverse` | `text` | "Reverse 'hello world'" |
+| `word_stats` | `text` | "Count words in this sentence" |
+
+Resource `mcp://hello/welcome` — a static welcome message.
+
+---
+
+## Docker Desktop MCP Toolkit (bonus)
+
+Docker Desktop 4.62+ has a built-in MCP Catalog. To register your own server:
+
+1. Package it as a Docker image: `docker build -t mcp-hello .`
+2. In Docker Desktop → Extensions → MCP Toolkit, add a custom server pointing
+   to your image with `CMD ["python", "server.py", "--transport", "http"]`.
+3. Connect it to Claude Desktop via the Clients tab → Claude Desktop.
+4. Restart Claude Desktop.
+
+This way Docker manages the server lifecycle and your MCP tools appear
+automatically in Claude Desktop without manual config file editing.
+
+---
+
+## Project layout explained
+
+```
+server.py   FastMCP server
+            - @mcp.tool()     → decorated functions become callable tools
+            - @mcp.resource() → URI-addressable read-only data
+            - mcp.run(transport="stdio"|"streamable-http")
+
+client.py   CLI chatbot (stdio)
+            - StdioServerParameters → spawn server.py as subprocess
+            - ClientSession.list_tools() + call_tool()
+            - Anthropic().messages.create() with tool schemas
+            - Agentic loop until stop_reason != "tool_use"
+
+webapp.py   Web chatbot (HTTP)
+            - streamablehttp_client("http://...") → connect to running server
+            - Same agentic loop, wrapped in a Flask POST /chat endpoint
+            - Serves templates/index.html
+
+templates/index.html
+            Vanilla HTML/CSS/JS chatbot UI
+            - fetch("/chat", ...) on submit
+            - Suggestion pills for quick demos
+```

--- a/python/mcp-hello/claude_desktop_config.json
+++ b/python/mcp-hello/claude_desktop_config.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Add the mcpServers block to: ~/Library/Application Support/Claude/claude_desktop_config.json",
+  "mcpServers": {
+    "hello-world": {
+      "command": "python",
+      "args": ["/ABSOLUTE/PATH/TO/python/mcp-hello/server.py"],
+      "_hint": "Replace the path above with the real absolute path on your machine."
+    }
+  }
+}

--- a/python/mcp-hello/client.py
+++ b/python/mcp-hello/client.py
@@ -1,0 +1,154 @@
+"""
+CLI chatbot — connects to the MCP server via stdio (spawns it as a subprocess).
+Uses the Anthropic API so Claude can call the MCP tools automatically.
+
+Usage:
+    python client.py          # interactive chat loop
+    python client.py "Hello"  # single query
+"""
+
+import asyncio
+import sys
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Optional
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+load_dotenv()
+
+SERVER_SCRIPT = Path(__file__).parent / "server.py"
+MODEL = "claude-sonnet-4-6"
+
+
+class MCPChatbot:
+    def __init__(self) -> None:
+        self.session: Optional[ClientSession] = None
+        self.exit_stack = AsyncExitStack()
+        self.anthropic = Anthropic()
+
+    # ── Connection ────────────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Launch server.py as a subprocess and open an MCP session over stdio."""
+        server_params = StdioServerParameters(
+            command=sys.executable,          # same python that runs this file
+            args=[str(SERVER_SCRIPT)],       # --transport stdio is the default
+            env=None,
+        )
+        transport = await self.exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        read, write = transport
+        self.session = await self.exit_stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await self.session.initialize()
+
+        tools = (await self.session.list_tools()).tools
+        names = [t.name for t in tools]
+        print(f"[MCP] Connected to server. Tools available: {names}\n")
+
+    # ── Chat ──────────────────────────────────────────────────────────────────
+
+    async def chat(self, user_message: str) -> str:
+        """Send a message to Claude; let it call MCP tools as needed."""
+        assert self.session, "Not connected — call connect() first."
+
+        # Build tool schemas from the live MCP server
+        tools = (await self.session.list_tools()).tools
+        tool_schemas = [
+            {
+                "name": t.name,
+                "description": t.description,
+                "input_schema": t.inputSchema,
+            }
+            for t in tools
+        ]
+
+        messages = [{"role": "user", "content": user_message}]
+
+        # Agentic loop: keep going until Claude stops requesting tools
+        while True:
+            response = self.anthropic.messages.create(
+                model=MODEL,
+                max_tokens=1024,
+                tools=tool_schemas,
+                messages=messages,
+            )
+
+            # Collect text blocks from this turn
+            text_parts = [
+                block.text
+                for block in response.content
+                if block.type == "text"
+            ]
+
+            if response.stop_reason != "tool_use":
+                return "\n".join(text_parts)
+
+            # Execute every tool_use block via the MCP server
+            tool_results = []
+            for block in response.content:
+                if block.type != "tool_use":
+                    continue
+                result = await self.session.call_tool(block.name, block.input)
+                result_text = "".join(
+                    c.text for c in result.content if hasattr(c, "text")
+                )
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result_text,
+                    }
+                )
+                print(f"  [tool] {block.name}({block.input}) → {result_text}")
+
+            # Extend conversation with assistant turn + tool results
+            messages.append({"role": "assistant", "content": response.content})
+            messages.append({"role": "user", "content": tool_results})
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        await self.exit_stack.aclose()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+async def run() -> None:
+    bot = MCPChatbot()
+    await bot.connect()
+
+    # Single-query mode
+    if len(sys.argv) > 1:
+        query = " ".join(sys.argv[1:])
+        answer = await bot.chat(query)
+        print(f"\nAssistant: {answer}")
+        await bot.close()
+        return
+
+    # Interactive loop
+    print("MCP Chatbot — type 'quit' or Ctrl-C to exit.\n")
+    try:
+        while True:
+            try:
+                query = input("You: ").strip()
+            except EOFError:
+                break
+            if not query:
+                continue
+            if query.lower() in {"quit", "exit", "q"}:
+                break
+            answer = await bot.chat(query)
+            print(f"\nAssistant: {answer}\n")
+    finally:
+        await bot.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/python/mcp-hello/client_local.py
+++ b/python/mcp-hello/client_local.py
@@ -1,0 +1,139 @@
+"""
+CLI chatbot — local LLM via Ollama, no API key needed.
+Uses the MCP server over stdio (spawns it as a subprocess).
+
+Requirements:
+  brew install ollama
+  ollama pull qwen2.5:7b        # or llama3.1:8b, mistral:7b-instruct
+  ollama serve                  # (auto-starts on macOS after brew install)
+
+Usage:
+  python client_local.py
+  OLLAMA_MODEL=llama3.1:8b python client_local.py
+"""
+
+import asyncio
+import os
+import sys
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Optional
+
+import ollama
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+SERVER_SCRIPT = Path(__file__).parent / "server.py"
+MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5:7b")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+
+
+def _to_ollama_tools(mcp_tools) -> list[dict]:
+    """Convert MCP tool schemas to Ollama/OpenAI function-calling format."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description or "",
+                "parameters": t.inputSchema,
+            },
+        }
+        for t in mcp_tools
+    ]
+
+
+class LocalMCPChatbot:
+    def __init__(self) -> None:
+        self.session: Optional[ClientSession] = None
+        self.exit_stack = AsyncExitStack()
+        self.ollama = ollama.Client(host=OLLAMA_HOST)
+
+    async def connect(self) -> None:
+        server_params = StdioServerParameters(
+            command=sys.executable,
+            args=[str(SERVER_SCRIPT)],
+            env=None,
+        )
+        transport = await self.exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        read, write = transport
+        self.session = await self.exit_stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await self.session.initialize()
+
+        tools = (await self.session.list_tools()).tools
+        names = [t.name for t in tools]
+        print(f"[MCP] Connected. Tools: {names}")
+        print(f"[LLM] Using Ollama model: {MODEL}  ({OLLAMA_HOST})\n")
+
+    async def chat(self, user_message: str) -> str:
+        assert self.session
+
+        mcp_tools = (await self.session.list_tools()).tools
+        tools = _to_ollama_tools(mcp_tools)
+
+        messages: list = [{"role": "user", "content": user_message}]
+
+        # Agentic loop
+        while True:
+            response = self.ollama.chat(
+                model=MODEL,
+                messages=messages,
+                tools=tools,
+            )
+            msg = response.message
+
+            # No more tool calls — return final text
+            if not msg.tool_calls:
+                return msg.content or ""
+
+            # Add assistant turn (with pending tool calls)
+            messages.append(msg)
+
+            # Execute each tool via MCP
+            for tc in msg.tool_calls:
+                name = tc.function.name
+                args = dict(tc.function.arguments)
+                result = await self.session.call_tool(name, args)
+                result_text = "".join(
+                    c.text for c in result.content if hasattr(c, "text")
+                )
+                print(f"  [tool] {name}({args}) → {result_text}")
+                messages.append({"role": "tool", "content": result_text})
+
+    async def close(self) -> None:
+        await self.exit_stack.aclose()
+
+
+async def run() -> None:
+    bot = LocalMCPChatbot()
+    await bot.connect()
+
+    if len(sys.argv) > 1:
+        answer = await bot.chat(" ".join(sys.argv[1:]))
+        print(f"\nAssistant: {answer}")
+        await bot.close()
+        return
+
+    print("Local MCP Chatbot — type 'quit' or Ctrl-C to exit.\n")
+    try:
+        while True:
+            try:
+                query = input("You: ").strip()
+            except EOFError:
+                break
+            if not query:
+                continue
+            if query.lower() in {"quit", "exit", "q"}:
+                break
+            answer = await bot.chat(query)
+            print(f"\nAssistant: {answer}\n")
+    finally:
+        await bot.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/python/mcp-hello/docker-compose.local.yml
+++ b/python/mcp-hello/docker-compose.local.yml
@@ -1,0 +1,50 @@
+# Local LLM stack — uses Ollama running natively on macOS (host machine).
+#
+# WHY not run Ollama in Docker on macOS?
+#   Docker Desktop containers can't access the Mac's Metal GPU, so inference
+#   would be CPU-only and very slow. Running Ollama natively uses Metal GPU
+#   acceleration, then pointing Docker containers at host.docker.internal
+#   lets them talk to it without any speed penalty.
+#
+# Setup (one-time):
+#   brew install ollama
+#   ollama pull qwen2.5:7b          # ~4 GB, runs well on 8 GB RAM M-series Macs
+#   ollama serve                    # starts on http://localhost:11434
+#
+# Then:
+#   docker compose -f docker-compose.local.yml up --build
+#   open http://localhost:5000
+
+services:
+
+  # ── MCP Server (same as the Anthropic stack) ───────────────────────────────
+  mcp-server:
+    build: .
+    command: python server.py --transport http
+    ports:
+      - "8000:8000"
+    environment:
+      MCP_HOST: "0.0.0.0"
+      MCP_PORT: "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/mcp')"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # ── Web Chatbot (local LLM) ────────────────────────────────────────────────
+  chatbot:
+    build: .
+    command: python webapp_local.py
+    ports:
+      - "5000:5000"
+    environment:
+      MCP_SERVER_URL: "http://mcp-server:8000/mcp"
+      # host.docker.internal resolves to your Mac — Ollama runs there with Metal GPU
+      OLLAMA_HOST: "http://host.docker.internal:11434"
+      OLLAMA_MODEL: "qwen2.5:7b"   # change to llama3.1:8b, mistral:7b-instruct, etc.
+      WEBAPP_PORT: "5000"
+    depends_on:
+      mcp-server:
+        condition: service_healthy

--- a/python/mcp-hello/docker-compose.yml
+++ b/python/mcp-hello/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+
+  # ── MCP Server (HTTP transport) ─────────────────────────────────────────────
+  mcp-server:
+    build: .
+    command: python server.py --transport http
+    ports:
+      - "8000:8000"
+    environment:
+      MCP_HOST: "0.0.0.0"
+      MCP_PORT: "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/mcp')"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # ── Web Chatbot ─────────────────────────────────────────────────────────────
+  chatbot:
+    build: .
+    command: python webapp.py
+    ports:
+      - "5000:5000"
+    environment:
+      MCP_SERVER_URL: "http://mcp-server:8000/mcp"
+      WEBAPP_PORT: "5000"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+    depends_on:
+      mcp-server:
+        condition: service_healthy

--- a/python/mcp-hello/pyproject.toml
+++ b/python/mcp-hello/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]>=1.6.0",
     "anthropic>=0.45.0",
+    "ollama>=0.4.0",
     "flask>=3.1.0",
     "pytz>=2024.1",
     "python-dotenv>=1.0.0",

--- a/python/mcp-hello/pyproject.toml
+++ b/python/mcp-hello/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "mcp-hello"
+version = "0.1.0"
+description = "Hello World MCP server + chatbot demo"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.6.0",
+    "anthropic>=0.45.0",
+    "flask>=3.1.0",
+    "pytz>=2024.1",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+mcp-hello-server = "server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/python/mcp-hello/server.py
+++ b/python/mcp-hello/server.py
@@ -1,0 +1,151 @@
+"""
+Hello World MCP Server — FastMCP demo with tools and a resource.
+
+Supports two transports:
+  stdio  (default) — used by Claude Desktop and the CLI client
+  http             — used by the web chatbot and Docker Compose
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+import pytz
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(
+    "hello-world-mcp",
+    instructions=(
+        "A hello-world MCP server that demonstrates tools and resources. "
+        "Use it to greet people, get the current time, do math, reverse text, "
+        "or count words."
+    ),
+)
+
+
+# ── Tools ────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def greet(name: str, style: str = "friendly") -> str:
+    """Greet someone by name with a chosen style.
+
+    Args:
+        name: The person's name.
+        style: One of "friendly" (default), "formal", or "pirate".
+    """
+    styles = {
+        "friendly": f"Hey {name}! Great to meet you! 👋",
+        "formal": f"Good day, {name}. It is a pleasure to make your acquaintance.",
+        "pirate": f"Ahoy, {name}! Welcome aboard, ye landlubber! ☠️",
+    }
+    return styles.get(style, styles["friendly"])
+
+
+@mcp.tool()
+def get_time(timezone: str = "UTC") -> str:
+    """Get the current date and time in a given timezone.
+
+    Args:
+        timezone: IANA timezone name, e.g. "UTC", "US/Pacific", "Europe/Paris".
+    """
+    try:
+        tz = pytz.timezone(timezone)
+        now = datetime.now(tz)
+        return f"Current time in {timezone}: {now.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+    except pytz.UnknownTimeZoneError:
+        return (
+            f"Unknown timezone '{timezone}'. "
+            "Try 'UTC', 'US/Pacific', 'Europe/London', 'Asia/Tokyo', etc."
+        )
+
+
+@mcp.tool()
+def add(a: float, b: float) -> str:
+    """Add two numbers.
+
+    Args:
+        a: First number.
+        b: Second number.
+    """
+    return f"{a} + {b} = {a + b}"
+
+
+@mcp.tool()
+def reverse(text: str) -> str:
+    """Reverse a string.
+
+    Args:
+        text: The text to reverse.
+    """
+    return text[::-1]
+
+
+@mcp.tool()
+def word_stats(text: str) -> str:
+    """Count words and characters in a piece of text.
+
+    Args:
+        text: The text to analyse.
+    """
+    words = len(text.split())
+    chars = len(text)
+    no_spaces = len(text.replace(" ", ""))
+    return (
+        f"Words: {words} | Characters: {chars} | "
+        f"Characters (no spaces): {no_spaces}"
+    )
+
+
+# ── Resource ─────────────────────────────────────────────────────────────────
+
+@mcp.resource("mcp://hello/welcome")
+def welcome() -> str:
+    """A static welcome message exposed as an MCP resource."""
+    return (
+        "Welcome to the Hello World MCP Server!\n"
+        "Available tools: greet, get_time, add, reverse, word_stats.\n"
+        "Ask me to greet you, tell you the time in Tokyo, add numbers, etc."
+    )
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hello World MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport layer: 'stdio' (default, for Claude Desktop / CLI) "
+             "or 'http' (for the web chatbot / Docker).",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("MCP_HOST", "0.0.0.0"),
+        help="Host for HTTP transport (default: 0.0.0.0).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("MCP_PORT", "8000")),
+        help="Port for HTTP transport (default: 8000).",
+    )
+    args = parser.parse_args()
+
+    if args.transport == "http":
+        print(
+            f"[MCP] Starting HTTP server at http://{args.host}:{args.port}/mcp",
+            file=sys.stderr,
+        )
+        # FastMCP reads FASTMCP_HOST / FASTMCP_PORT env-vars automatically;
+        # set them from our CLI args so callers don't have to duplicate them.
+        os.environ.setdefault("FASTMCP_HOST", args.host)
+        os.environ.setdefault("FASTMCP_PORT", str(args.port))
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mcp-hello/templates/index.html
+++ b/python/mcp-hello/templates/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MCP Hello World Chatbot</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    header {
+      width: 100%;
+      max-width: 760px;
+      padding: 1.25rem 1rem 0.5rem;
+    }
+
+    header h1 { font-size: 1.3rem; font-weight: 600; color: #a78bfa; }
+    header p  { font-size: 0.8rem; color: #64748b; margin-top: 0.25rem; }
+
+    .pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      padding: 0.5rem 1rem;
+      width: 100%;
+      max-width: 760px;
+    }
+
+    .pill {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: 0.3rem 0.75rem;
+      font-size: 0.78rem;
+      cursor: pointer;
+      color: #94a3b8;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .pill:hover { border-color: #a78bfa; color: #a78bfa; }
+
+    #chat {
+      flex: 1;
+      width: 100%;
+      max-width: 760px;
+      overflow-y: auto;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .msg {
+      display: flex;
+      gap: 0.6rem;
+      max-width: 92%;
+    }
+    .msg.user  { align-self: flex-end; flex-direction: row-reverse; }
+    .msg.bot   { align-self: flex-start; }
+
+    .avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      flex-shrink: 0;
+    }
+    .msg.user .avatar { background: #4f46e5; }
+    .msg.bot  .avatar { background: #1e293b; border: 1px solid #334155; }
+
+    .bubble {
+      padding: 0.65rem 0.9rem;
+      border-radius: 12px;
+      font-size: 0.92rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .msg.user .bubble { background: #4f46e5; color: #fff; border-radius: 12px 2px 12px 12px; }
+    .msg.bot  .bubble { background: #1e293b; color: #e2e8f0; border-radius: 2px 12px 12px 12px; }
+
+    .typing .bubble { color: #64748b; font-style: italic; }
+
+    footer {
+      width: 100%;
+      max-width: 760px;
+      padding: 0.75rem 1rem 1.25rem;
+    }
+
+    .input-row {
+      display: flex;
+      gap: 0.5rem;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 0.4rem 0.4rem 0.4rem 1rem;
+    }
+    .input-row:focus-within { border-color: #a78bfa; }
+
+    #msg-input {
+      flex: 1;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: #e2e8f0;
+      font-size: 0.92rem;
+      resize: none;
+      max-height: 120px;
+      line-height: 1.5;
+      padding: 0.3rem 0;
+    }
+    #msg-input::placeholder { color: #475569; }
+
+    #send-btn {
+      background: #4f46e5;
+      border: none;
+      border-radius: 8px;
+      color: #fff;
+      width: 38px;
+      height: 38px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      align-self: flex-end;
+      transition: background 0.15s;
+    }
+    #send-btn:hover:not(:disabled) { background: #6366f1; }
+    #send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .hint {
+      text-align: center;
+      font-size: 0.72rem;
+      color: #475569;
+      margin-top: 0.4rem;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>MCP Hello World Chatbot</h1>
+  <p>Powered by Claude + MCP server at <code>{{ mcp_server_url }}</code></p>
+</header>
+
+<div class="pills" id="suggestions">
+  <button class="pill" onclick="send('Greet me as a pirate!')">Pirate greeting</button>
+  <button class="pill" onclick="send('What time is it in Tokyo?')">Time in Tokyo</button>
+  <button class="pill" onclick="send('Add 42 and 58')">Add numbers</button>
+  <button class="pill" onclick="send('Reverse the word \"MCP rocks\"')">Reverse text</button>
+  <button class="pill" onclick="send('Count the words in: The quick brown fox jumps over the lazy dog')">Word stats</button>
+  <button class="pill" onclick="send('What tools do you have?')">List tools</button>
+</div>
+
+<div id="chat"></div>
+
+<footer>
+  <div class="input-row">
+    <textarea id="msg-input" rows="1" placeholder="Ask anything — try the suggestions above…"></textarea>
+    <button id="send-btn" onclick="sendFromInput()" title="Send (Enter)">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="22" y1="2" x2="11" y2="13"></line>
+        <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+      </svg>
+    </button>
+  </div>
+  <p class="hint">Enter to send &nbsp;·&nbsp; Shift+Enter for newline</p>
+</footer>
+
+<script>
+  const chat    = document.getElementById("chat");
+  const input   = document.getElementById("msg-input");
+  const sendBtn = document.getElementById("send-btn");
+
+  // Auto-grow textarea
+  input.addEventListener("input", () => {
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 120) + "px";
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendFromInput(); }
+  });
+
+  function appendMsg(role, text) {
+    const div = document.createElement("div");
+    div.className = `msg ${role}`;
+    div.innerHTML = `
+      <div class="avatar">${role === "user" ? "🧑" : "🤖"}</div>
+      <div class="bubble">${escHtml(text)}</div>
+    `;
+    chat.appendChild(div);
+    chat.scrollTop = chat.scrollHeight;
+    return div;
+  }
+
+  function escHtml(t) {
+    return t.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+  }
+
+  function sendFromInput() {
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = "";
+    input.style.height = "auto";
+    send(text);
+  }
+
+  async function send(message) {
+    appendMsg("user", message);
+    sendBtn.disabled = true;
+
+    const typing = appendMsg("bot", "Thinking…");
+    typing.classList.add("typing");
+
+    try {
+      const res = await fetch("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+      });
+      const data = await res.json();
+      typing.remove();
+      if (data.error) {
+        appendMsg("bot", "Error: " + data.error);
+      } else {
+        appendMsg("bot", data.response);
+      }
+    } catch (err) {
+      typing.remove();
+      appendMsg("bot", "Network error: " + err.message);
+    } finally {
+      sendBtn.disabled = false;
+      input.focus();
+    }
+  }
+</script>
+</body>
+</html>

--- a/python/mcp-hello/webapp.py
+++ b/python/mcp-hello/webapp.py
@@ -1,0 +1,118 @@
+"""
+Web chatbot — Flask app that acts as an MCP client (HTTP transport).
+It serves a simple HTML UI and proxies chat messages through Claude + the MCP server.
+
+Requires the MCP server to be running in HTTP mode:
+    python server.py --transport http
+
+Usage:
+    python webapp.py          # then open http://localhost:5000
+"""
+
+import asyncio
+import os
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+from flask import Flask, jsonify, render_template, request
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+load_dotenv()
+
+app = Flask(__name__)
+anthropic = Anthropic()
+
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+MODEL = "claude-sonnet-4-6"
+
+
+# ── MCP helpers ───────────────────────────────────────────────────────────────
+
+async def _process_message(user_message: str) -> str:
+    """Open a fresh MCP session, fetch tools, run Claude's agentic loop."""
+    async with streamablehttp_client(MCP_SERVER_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = (await session.list_tools()).tools
+            tool_schemas = [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.inputSchema,
+                }
+                for t in tools
+            ]
+
+            messages = [{"role": "user", "content": user_message}]
+
+            # Agentic loop
+            while True:
+                response = anthropic.messages.create(
+                    model=MODEL,
+                    max_tokens=1024,
+                    tools=tool_schemas,
+                    messages=messages,
+                )
+
+                text_parts = [
+                    b.text for b in response.content if b.type == "text"
+                ]
+
+                if response.stop_reason != "tool_use":
+                    return "\n".join(text_parts)
+
+                tool_results = []
+                for block in response.content:
+                    if block.type != "tool_use":
+                        continue
+                    result = await session.call_tool(block.name, block.input)
+                    result_text = "".join(
+                        c.text for c in result.content if hasattr(c, "text")
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": result_text,
+                        }
+                    )
+
+                messages.append({"role": "assistant", "content": response.content})
+                messages.append({"role": "user", "content": tool_results})
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@app.route("/")
+def index():
+    return render_template("index.html", mcp_server_url=MCP_SERVER_URL)
+
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    data = request.get_json(silent=True) or {}
+    message = (data.get("message") or "").strip()
+    if not message:
+        return jsonify({"error": "No message provided"}), 400
+
+    try:
+        answer = asyncio.run(_process_message(message))
+        return jsonify({"response": answer})
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"error": str(exc)}), 500
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok", "mcp_server": MCP_SERVER_URL})
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    port = int(os.getenv("WEBAPP_PORT", "5000"))
+    print(f"Web chatbot at http://localhost:{port}")
+    print(f"Connecting to MCP server at {MCP_SERVER_URL}")
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/python/mcp-hello/webapp_local.py
+++ b/python/mcp-hello/webapp_local.py
@@ -1,0 +1,113 @@
+"""
+Web chatbot (local LLM) — Flask app that connects to the MCP server via HTTP
+and uses Ollama instead of the Anthropic API.
+
+Requires the MCP server running in HTTP mode:
+    python server.py --transport http
+
+And Ollama running locally (or via OLLAMA_HOST):
+    brew install ollama && ollama pull qwen2.5:7b && ollama serve
+
+Usage:
+    python webapp_local.py       # then open http://localhost:5000
+
+Docker Compose (with Ollama on host macOS):
+    OLLAMA_HOST=http://host.docker.internal:11434 \
+    docker compose -f docker-compose.local.yml up --build
+"""
+
+import asyncio
+import os
+
+import ollama
+from flask import Flask, jsonify, render_template, request
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+app = Flask(__name__)
+
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5:7b")
+
+
+def _to_ollama_tools(mcp_tools) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description or "",
+                "parameters": t.inputSchema,
+            },
+        }
+        for t in mcp_tools
+    ]
+
+
+async def _process_message(user_message: str) -> str:
+    client = ollama.Client(host=OLLAMA_HOST)
+
+    async with streamablehttp_client(MCP_SERVER_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            mcp_tools = (await session.list_tools()).tools
+            tools = _to_ollama_tools(mcp_tools)
+
+            messages: list = [{"role": "user", "content": user_message}]
+
+            while True:
+                response = client.chat(model=MODEL, messages=messages, tools=tools)
+                msg = response.message
+
+                if not msg.tool_calls:
+                    return msg.content or ""
+
+                messages.append(msg)
+
+                for tc in msg.tool_calls:
+                    name = tc.function.name
+                    args = dict(tc.function.arguments)
+                    result = await session.call_tool(name, args)
+                    result_text = "".join(
+                        c.text for c in result.content if hasattr(c, "text")
+                    )
+                    messages.append({"role": "tool", "content": result_text})
+
+
+@app.route("/")
+def index():
+    return render_template(
+        "index.html",
+        mcp_server_url=MCP_SERVER_URL,
+        extra_info=f"Local LLM: {MODEL} via {OLLAMA_HOST}",
+    )
+
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    data = request.get_json(silent=True) or {}
+    message = (data.get("message") or "").strip()
+    if not message:
+        return jsonify({"error": "No message provided"}), 400
+    try:
+        answer = asyncio.run(_process_message(message))
+        return jsonify({"response": answer})
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"error": str(exc)}), 500
+
+
+@app.route("/health")
+def health():
+    return jsonify(
+        {"status": "ok", "mcp_server": MCP_SERVER_URL, "llm": MODEL, "ollama": OLLAMA_HOST}
+    )
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("WEBAPP_PORT", "5000"))
+    print(f"Web chatbot (local LLM) at http://localhost:{port}")
+    print(f"MCP server : {MCP_SERVER_URL}")
+    print(f"Ollama     : {OLLAMA_HOST}  model={MODEL}")
+    app.run(host="0.0.0.0", port=port, debug=False)


### PR DESCRIPTION
Demonstrates how Model Context Protocol works end-to-end with three
run modes: CLI chatbot (stdio), web chatbot + HTML UI (Docker Compose /
HTTP transport), and Claude Desktop integration.

- server.py: FastMCP server with 5 tools (greet, get_time, add, reverse,
  word_stats) and an mcp://hello/welcome resource
- client.py: CLI chatbot using stdio transport + Anthropic API agentic loop
- webapp.py: Flask chatbot that connects to the MCP server via streamable-http
- templates/index.html: vanilla HTML/CSS/JS chat UI with suggestion pills
- Dockerfile + docker-compose.yml: full stack (mcp-server + chatbot services)
- claude_desktop_config.json: ready-to-paste Claude Desktop snippet
- README.md: step-by-step guide covering all four options incl. MCP Inspector

https://claude.ai/code/session_01ELYyvEL1Z943njj9NPCQtB